### PR TITLE
sbds_tx_delete_comments's table "permlink" column size update

### DIFF
--- a/sbds/storages/db/tables/tx.py
+++ b/sbds/storages/db/tables/tx.py
@@ -1127,7 +1127,7 @@ class TxDeleteComment(Base, TxBase):
     __tablename__ = 'sbds_tx_delete_comments'
 
     author = Column(Unicode(50), nullable=False)
-    permlink = Column(Unicode(250), nullable=False)
+    permlink = Column(Unicode(512), nullable=False)
 
     _fields = dict(delete_comment=dict(
         author=lambda x: x.get('author'),

--- a/sbds/storages/db/tables/tx.py
+++ b/sbds/storages/db/tables/tx.py
@@ -1127,7 +1127,7 @@ class TxDeleteComment(Base, TxBase):
     __tablename__ = 'sbds_tx_delete_comments'
 
     author = Column(Unicode(50), nullable=False)
-    permlink = Column(Unicode(512), nullable=False)
+    permlink = Column(Unicode(256), nullable=False)
 
     _fields = dict(delete_comment=dict(
         author=lambda x: x.get('author'),


### PR DESCRIPTION
"permlink" column has only 250 size, it should have 512 to have a uniform size across tables